### PR TITLE
Fix imports and make DidRecord marker field optional

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,7 @@
   "name": "@sicpa-dlab/aries-framework-core",
   "main": "build/index",
   "types": "build/index",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "files": [
     "build"
   ],

--- a/packages/core/src/agent/didcomm/index.ts
+++ b/packages/core/src/agent/didcomm/index.ts
@@ -1,6 +1,7 @@
 import type { ParsedMessageType } from '../../utils/messageType'
 import type { Constructor } from '../../utils/mixins'
-import type { DIDCommV1Message, DIDCommV2Message } from '@aries-framework/core'
+import type { DIDCommV1Message } from './v1/DIDCommV1Message'
+import type { DIDCommV2Message } from './v2/DIDCommV2Message'
 
 export { DIDCommMessage } from './DIDCommMessage'
 export { DIDCommV1Message } from './v1/DIDCommV1Message'

--- a/packages/core/src/modules/dids/repository/DidRecord.ts
+++ b/packages/core/src/modules/dids/repository/DidRecord.ts
@@ -60,6 +60,7 @@ export class DidRecord extends BaseRecord<DefaultDidTags, CustomDidTags, DidReco
   @IsBoolean()
   public isStatic!: boolean
 
+  @IsOptional()
   @IsEnum(DidMarker)
   public marker?: DidMarker
 

--- a/packages/core/src/modules/routing/services/MediationRecipientService.ts
+++ b/packages/core/src/modules/routing/services/MediationRecipientService.ts
@@ -4,10 +4,10 @@ import type { InboundMessageContext } from '../../../agent/models/InboundMessage
 import type { EncryptedMessage } from '../../../types'
 import type { ConnectionRecord } from '../../connections'
 import type { Routing } from '../../connections/services/ConnectionService'
+import type { GetRoutingOptions } from '../../routing'
 import type { DidListUpdatedEvent, MediationStateChangedEvent } from '../RoutingEvents'
 import type { MediationDenyMessageV2, MediationGrantMessageV2, DidListUpdateResponseMessage } from '../messages'
 import type { StatusMessage, MessageDeliveryMessage } from '../protocol'
-import type { GetRoutingOptions } from '@aries-framework/core'
 
 import { firstValueFrom, ReplaySubject } from 'rxjs'
 import { filter, first, timeout } from 'rxjs/operators'

--- a/packages/core/src/modules/routing/services/RoutingService.ts
+++ b/packages/core/src/modules/routing/services/RoutingService.ts
@@ -1,6 +1,6 @@
 import type { Routing } from '../../connections'
+import type { GetRoutingOptions } from '../../routing'
 import type { MediationRecord } from '../repository'
-import type { GetRoutingOptions } from '@aries-framework/core'
 
 import { AgentConfig } from '../../../agent/AgentConfig'
 import { EventEmitter } from '../../../agent/EventEmitter'

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -2,7 +2,7 @@
   "name": "@sicpa-dlab/aries-framework-node",
   "main": "build/index",
   "types": "build/index",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "files": [
     "build",
     "bin"

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -2,7 +2,7 @@
   "name": "@sicpa-dlab/aries-framework-react-native",
   "main": "build/index",
   "types": "build/index",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "files": [
     "build"
   ],


### PR DESCRIPTION
# Fix imports and make DidRecord marker field optional

<!--- Fill title in the form above -->
<!--- Template: [area] ... -->

**Related ticket on Github:** #

**Mention reviewers (and add to reviewers list manually)**

<!--- Please add or remove reviewers so that only people who are interested in this change get notified -->

- @Artemkaaas
- @dmitry-vychikov 

## Description

<!--- 2 short sentences about what you changed in the code -->
Minor fixes after updating from upstream.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If something does not make sense or does not apply – leave unchecked  --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### Mgmt (common)

- [ ] Link to related ticket attached
- [x] Added list of _reviewers_ to Github reviewers section
- [x] Added at least one (at most two) _assignees_ to the PR (somebody from the reviewers section)
- [x] Selected `CBDC DIDComm (Beta)` in `Project` field
  - [x] Moved this PR into current sprint
  - [ ] Double-checked that the linked issues belongs to the Current sprint

### Code review (common)

- [x] I think this PR is good and want to submit it for review
- [x] I have looked through this PR myself and fixed issues that I found during manual review
- [ ] I have already documented questions or places in the code that I do not feel confident about

### Documentation & design (common)

- [x] My change corresponds to design decisions from `cbdc-design` or `cbdc-projects` repo
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly (attach a link to PR with changes)
  - [ ] I have created a corresponding task to update documentation and assigned it to responsible person (attach a link to task)

### Development (specific to Aries Framework Repo)

- I have properly tested my changes
  - [ ] I have tested on a demo app
    - [x] I also build mobile apps and tested real transactions on a real Android device
    - [ ] I also build mobile apps and tested real transactions on a real IOS device
  - [x] I built my code on Windows
  - [ ] I built tested on Mac OS
  - [ ] I built my code on Linux
- [ ] I have considered platform differences
  - [ ] I'm using environment-aware scripts (bash, env, build scripts)
 [ ] I have published a [pre-release package of AFJ](TODO:link-to-readme), installed and tested it in other apps

### Dependencies (specific to Aries Framework Repo)

- This PR depends on other PRs (check only relevant items)
  - [ ] [VTP/Gossip library PR](PR link)
  - [ ] All the other PR's have been merged in, so it's time to merge Aries Framework too
- This PR requires us to also update
  - [x] Update Mobile applications
    - [x] [Mobile Apps PR link](https://github.com/sicpa-dlab/value-transfer-ui-mobile/pull/264)
    - [x] [Backend Apps PR link](https://github.com/sicpa-dlab/value-transfer-protocol/pull/172)

### Versioning and backwards compatibility (specific to Mobile repo)

- Backwards compatibility (check only one)
  - [ ] This PR breaks compatibility with older version of Aries Framework Javascript
  - [ ] This PR will be compatible with older version of Aries Framework Javascript
- Do we need to bump major app version?
  - [x] Small change, bumping only minor version via CI script is fine (need to be done manual)
  - [ ] Larger change, so need to bump major version (need to be done manually)

