### PR TITLE
Raise event with new record state even when VTP library returned error

### DIFF
--- a/packages/core/src/modules/value-transfer/services/ValueTransferGetterService.ts
+++ b/packages/core/src/modules/value-transfer/services/ValueTransferGetterService.ts
@@ -221,11 +221,10 @@ export class ValueTransferGetterService {
     const { error, transaction, message } = await this.getter.acceptCash(requestAcceptanceWitnessed)
     if (error || !transaction || !message) {
       this.logger.error(`VTP: Failed to process Request Acceptance: ${error?.message}`)
-      return {}
     }
 
     // Raise event
-    const updatedRecord = await this.valueTransferService.emitStateChangedEvent(transaction.id)
+    const updatedRecord = await this.valueTransferService.emitStateChangedEvent(requestAcceptanceWitnessed.thid)
 
     this.logger.info(
       `< Getter: process request acceptance message for VTP transaction ${requestAcceptedWitnessedMessage.thid}`
@@ -253,11 +252,10 @@ export class ValueTransferGetterService {
     const { error, transaction, message } = await this.getter.processReceipt(receipt)
     if (error || !transaction || !message) {
       this.logger.error(`VTP: Failed to process Receipt: ${error?.message}`)
-      return {}
     }
 
     // Raise event
-    const record = await this.valueTransferService.emitStateChangedEvent(transaction.id)
+    const record = await this.valueTransferService.emitStateChangedEvent(receipt.thid)
 
     this.logger.info(`< Getter: process receipt message for VTP transaction ${getterReceiptMessage.thid} completed!`)
     return { record }

--- a/packages/core/src/modules/value-transfer/services/ValueTransferGiverService.ts
+++ b/packages/core/src/modules/value-transfer/services/ValueTransferGiverService.ts
@@ -151,11 +151,10 @@ export class ValueTransferGiverService {
       this.logger.error(
         ` Giver: process request message for VTP transaction ${requestMessage.id} failed. Error: ${error}`
       )
-      return {}
     }
 
     // Raise event
-    const record = await this.valueTransferService.emitStateChangedEvent(transaction.id)
+    const record = await this.valueTransferService.emitStateChangedEvent(requestMessage.id)
 
     // Save second party Did
     record.secondPartyDid = requestMessage.from
@@ -226,11 +225,10 @@ export class ValueTransferGiverService {
       this.logger.error(
         ` Giver: process cash acceptance message for VTP transaction ${cashAcceptedWitnessedMessage.thid} failed. Error: ${error}`
       )
-      return {}
     }
 
     // Raise event
-    const record = await this.valueTransferService.emitStateChangedEvent(transaction.id)
+    const record = await this.valueTransferService.emitStateChangedEvent(cashAcceptedWitnessedMessage.thid)
 
     this.logger.info(
       `< Giver: process cash acceptance message for VTP transaction ${cashAcceptedWitnessedMessage.thid} completed!`
@@ -263,11 +261,10 @@ export class ValueTransferGiverService {
       this.logger.error(
         ` Giver: process receipt message for VTP transaction ${receiptMessage.thid} failed. Error: ${error}`
       )
-      return {}
     }
 
     // Raise event
-    const record = await this.valueTransferService.emitStateChangedEvent(transaction.id)
+    const record = await this.valueTransferService.emitStateChangedEvent(receipt.thid)
 
     this.logger.info(`< Giver: process receipt message for VTP transaction ${receiptMessage.thid} completed!`)
 

--- a/packages/core/src/modules/value-transfer/services/ValueTransferWitnessService.ts
+++ b/packages/core/src/modules/value-transfer/services/ValueTransferWitnessService.ts
@@ -130,11 +130,10 @@ export class ValueTransferWitnessService {
         ` Giver: process cash acceptance message for VTP transaction ${cashAcceptedMessage.thid} failed.`,
         { error }
       )
-      return {}
     }
 
     // Rasie event
-    const record = await this.valueTransferService.emitStateChangedEvent(transaction.id)
+    const record = await this.valueTransferService.emitStateChangedEvent(cashAcceptedMessage.thid)
 
     this.logger.info(
       `< Witness ${this.label}: process cash acceptance message for VTP transaction ${cashAcceptedMessage.thid} completed!`
@@ -173,11 +172,10 @@ export class ValueTransferWitnessService {
       this.logger.error(` Giver: process cash removal message for VTP transaction ${cashRemovedMessage.thid} failed.`, {
         error,
       })
-      return {}
     }
 
     // Raise event
-    const record = await this.valueTransferService.emitStateChangedEvent(transaction.id)
+    const record = await this.valueTransferService.emitStateChangedEvent(cashRemovedMessage.thid)
 
     this.logger.info(
       `< Witness ${this.label}: process cash removal message for VTP transaction ${cashRemovedMessage.thid} completed!`


### PR DESCRIPTION
# Raise event with new record state even when VTP library returned error

<!--- Fill title in the form above -->
<!--- Template: [area] ... -->

**Related ticket on Github:** #1543

**Mention reviewers (and add to reviewers list manually)**

<!--- Please add or remove reviewers so that only people who are interested in this change get notified -->

- @AlexanderShenshin

## Description

When the processing of a message fails by VTP library this error is only logged into an output but not rethrown to the mobile app.
So the mobile app does not know about the error and cannot show it to the user

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If something does not make sense or does not apply – leave unchecked  --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### Mgmt (common)

- [x] Link to related ticket attached
- [x] Added list of _reviewers_ to Github reviewers section
- [x] Added at least one (at most two) _assignees_ to the PR (somebody from the reviewers section)
- [x] Selected `CBDC DIDComm (Beta)` in `Project` field
  - [x] Moved this PR into current sprint
  - [x] Double-checked that the linked issues belongs to the Current sprint

### Code review (common)

- [x] I think this PR is good and want to submit it for review
- [x] I have looked through this PR myself and fixed issues that I found during manual review