### PR TITLE
#1568/Include VTP record second party did field in state change events

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,7 @@
   "name": "@sicpa-dlab/aries-framework-core",
   "main": "build/index",
   "types": "build/index",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "files": [
     "build"
   ],

--- a/packages/core/src/modules/value-transfer/services/ValueTransferGetterService.ts
+++ b/packages/core/src/modules/value-transfer/services/ValueTransferGetterService.ts
@@ -117,12 +117,14 @@ export class ValueTransferGetterService {
       await this.valueTransferService.sendMessage(requestMessage, params.transport)
     }
 
-    // Raise event
-    const record = await this.valueTransferService.emitStateChangedEvent(transaction.id)
+    const record = await this.valueTransferService.getById(transaction.id)
 
     // Save second party Did
     record.secondPartyDid = requestMessage.to?.length ? requestMessage.to[0] : undefined
     await this.valueTransferRepository.update(record)
+
+    // Raise event
+    await this.valueTransferService.emitStateChangedEvent(record.id)
 
     this.logger.info(`< Getter: request payment VTP transaction completed`)
 
@@ -153,12 +155,14 @@ export class ValueTransferGetterService {
       return {}
     }
 
-    // Raise event
-    const record = await this.valueTransferService.emitStateChangedEvent(transaction.id)
+    const record = await this.valueTransferService.getById(transaction.id)
 
     // Save second party Did
     record.secondPartyDid = offerMessage.from
     await this.valueTransferRepository.update(record)
+
+    // Raise event
+    await this.valueTransferService.emitStateChangedEvent(record.id)
 
     this.logger.info(`< Getter: process offer message for VTP transaction ${offerMessage.thid} completed!`)
     return { record }

--- a/packages/core/src/modules/value-transfer/services/ValueTransferGiverService.ts
+++ b/packages/core/src/modules/value-transfer/services/ValueTransferGiverService.ts
@@ -118,12 +118,14 @@ export class ValueTransferGiverService {
       await this.valueTransferService.sendMessage(offerMessage, params.transport)
     }
 
-    // Raise event
-    const record = await this.valueTransferService.emitStateChangedEvent(transaction.id)
+    const record = await this.valueTransferService.getById(transaction.id)
 
     // Save second party Did
     record.secondPartyDid = offerMessage.to?.length ? offerMessage.to[0] : undefined
     await this.valueTransferRepository.update(record)
+
+    // Raise event
+    await this.valueTransferService.emitStateChangedEvent(record.id)
 
     this.logger.info(`< Giver: offer payment VTP transaction completed!`)
 
@@ -153,12 +155,14 @@ export class ValueTransferGiverService {
       return {}
     }
 
-    // Raise event
-    const record = await this.valueTransferService.emitStateChangedEvent(transaction.id)
+    const record = await this.valueTransferService.getById(transaction.id)
 
     // Save second party Did
     record.secondPartyDid = requestMessage.from
     await this.valueTransferRepository.update(record)
+
+    // Raise event
+    await this.valueTransferService.emitStateChangedEvent(record.id)
 
     this.logger.info(`< Giver: process payment request message for VTP transaction ${requestMessage.id} completed!`)
 


### PR DESCRIPTION
# Include VTP record second party did field in state change events

<!--- Fill title in the form above -->
<!--- Template: [area] ... -->

**Related ticket on Github:** [#1568](https://github.com/sicpa-dlab/cbdc-projects/issues/1568)

**Mention reviewers (and add to reviewers list manually)**

<!--- Please add or remove reviewers so that only people who are interested in this change get notified -->

- @Artemkaaas
- @dmitry-vychikov 

## Description

Small fix to include second party Did field in state change events for new transactions (we need to save second party did before sending events).

<!--- 2 short sentences about what you changed in the code -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If something does not make sense or does not apply – leave unchecked  --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### Mgmt (common)

- [x] Link to related ticket attached
- [x] Added list of _reviewers_ to Github reviewers section
- [x] Added at least one (at most two) _assignees_ to the PR (somebody from the reviewers section)
- [x] Selected `CBDC DIDComm (Beta)` in `Project` field
  - [x] Moved this PR into current sprint
  - [x] Double-checked that the linked issues belongs to the Current sprint

### Code review (common)

- [x] I think this PR is good and want to submit it for review
- [x] I have looked through this PR myself and fixed issues that I found during manual review
- [ ] I have already documented questions or places in the code that I do not feel confident about

### Documentation & design (common)

- [ ] My change corresponds to design decisions from `cbdc-design` or `cbdc-projects` repo
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly (attach a link to PR with changes)
  - [ ] I have created a corresponding task to update documentation and assigned it to responsible person (attach a link to task)

### Development (specific to Aries Framework Repo)

- I have properly tested my changes
  - [ ] I have tested on a demo app
    - [x] I also build mobile apps and tested real transactions on a real Android device
    - [ ] I also build mobile apps and tested real transactions on a real IOS device
  - [x] I built my code on Windows
  - [ ] I built tested on Mac OS
  - [ ] I built my code on Linux
- [ ] I have considered platform differences
  - [ ] I'm using environment-aware scripts (bash, env, build scripts)
        [x] I have published a [pre-release package of AFJ](TODO:link-to-readme), installed and tested it in other apps - `0.2.20-alpha.0`

### Dependencies (specific to Aries Framework Repo)

- This PR depends on other PRs (check only relevant items)
  - [ ] [VTP/Gossip library PR](PR link)
  - [ ] All the other PR's have been merged in, so it's time to merge Aries Framework too
- This PR requires us to also update
  - [x] Update Mobile applications
    - [x] [Mobile Apps PR link](PR Link)
    - [ ] [Backend Apps PR link](PR Link)

### Versioning and backwards compatibility (specific to Mobile repo)

- Backwards compatibility (check only one)
  - [ ] This PR breaks compatibility with older version of Aries Framework Javascript
  - [ ] This PR will be compatible with older version of Aries Framework Javascript
- Do we need to bump major app version?
  - [ ] Small change, bumping only minor version via CI script is fine (need to be done manual)
  - [ ] Larger change, so need to bump major version (need to be done manually)
