### PR TITLE
Define class for DidComm V2 attachment to make class-transformer working

### DIFF
--- a/packages/core/src/agent/didcomm/v2/DIDCommV2BaseMessage.ts
+++ b/packages/core/src/agent/didcomm/v2/DIDCommV2BaseMessage.ts
@@ -1,9 +1,9 @@
 import type { ParsedMessageType } from '../../../utils/messageType'
-import type { Attachment } from 'didcomm'
 
-import { Expose } from 'class-transformer'
-import { IsArray, IsNumber, IsOptional, IsString, Matches } from 'class-validator'
+import { Expose, Type } from 'class-transformer'
+import { IsArray, IsNumber, IsOptional, IsString, Matches, ValidateNested } from 'class-validator'
 
+import { V2Attachment } from '../../../decorators/attachment/V2Attachment'
 import { JsonEncoder } from '../../../utils'
 import { uuid } from '../../../utils/uuid'
 import { MessageIdRegExp, MessageTypeRegExp } from '../validation'
@@ -20,7 +20,7 @@ export type DIDCommV2MessageParams = {
   created_time?: number
   expires_time?: number
   from_prior?: string
-  attachments?: Array<Attachment>
+  attachments?: Array<V2Attachment>
   body?: unknown
 }
 
@@ -71,7 +71,12 @@ export class DIDCommV2BaseMessage {
   public body!: unknown
 
   @IsOptional()
-  public attachments?: Array<Attachment>
+  @Type(() => V2Attachment)
+  @IsArray()
+  @ValidateNested({
+    each: true,
+  })
+  public attachments?: Array<V2Attachment>
 
   public constructor(options?: DIDCommV2MessageParams) {
     if (options) {
@@ -93,7 +98,7 @@ export class DIDCommV2BaseMessage {
     return uuid()
   }
 
-  public static createJSONAttachment<T>(id: string, message: T): Attachment {
+  public static createJSONAttachment<T>(id: string, message: T): V2Attachment {
     return {
       id: id,
       // media_type: ATTACHMENT_MEDIA_TYPE,
@@ -104,7 +109,7 @@ export class DIDCommV2BaseMessage {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public static createBase64Attachment<T>(id: string, message: T): Attachment {
+  public static createBase64Attachment<T>(id: string, message: T): V2Attachment {
     return {
       id: id,
       // media_type: ATTACHMENT_MEDIA_TYPE,
@@ -114,7 +119,7 @@ export class DIDCommV2BaseMessage {
     }
   }
 
-  public static unpackAttachmentAsJson(attachment: Attachment) {
+  public static unpackAttachmentAsJson(attachment: V2Attachment) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const data = attachment.data as any //FIXME: didcomm package doesn't provide convenient way to process attachment
     if (typeof data.base64 === 'string') {

--- a/packages/core/src/decorators/attachment/V2Attachment.ts
+++ b/packages/core/src/decorators/attachment/V2Attachment.ts
@@ -1,0 +1,115 @@
+import { Expose, Type } from 'class-transformer'
+import { IsBase64, IsInstance, IsMimeType, IsOptional, IsString, ValidateNested } from 'class-validator'
+
+import { Jws } from '../../crypto/JwsTypes'
+import { uuid } from '../../utils/uuid'
+
+export interface V2AttachmentOptions {
+  id?: string
+  description?: string
+  filename?: string
+  mediaType?: string
+  byteCount?: number
+  data: AttachmentData
+}
+
+export interface AttachmentDataOptions {
+  base64?: string
+  json?: Record<string, unknown>
+  links?: string[]
+  jws?: Jws
+}
+
+/**
+ * A JSON object that gives access to the actual content of the attachment
+ */
+export class AttachmentData {
+  /**
+   * Base64-encoded data, when representing arbitrary content inline instead of via links. Optional.
+   */
+  @IsOptional()
+  @IsBase64()
+  public base64?: string
+
+  /**
+   *  Directly embedded JSON data, when representing content inline instead of via links, and when the content is natively conveyable as JSON. Optional.
+   */
+  @IsOptional()
+  public json?: unknown
+
+  /**
+   * A list of zero or more locations at which the content may be fetched. Optional.
+   */
+  @IsOptional()
+  @IsString({ each: true })
+  public links?: string[]
+
+  /**
+   * A JSON Web Signature over the content of the attachment. Optional.
+   */
+  @IsOptional()
+  public jws?: Jws
+
+  public constructor(options: AttachmentDataOptions) {
+    if (options) {
+      this.base64 = options.base64
+      this.json = options.json
+      this.links = options.links
+      this.jws = options.jws
+    }
+  }
+}
+
+/**
+ * Represents DIDComm attachment
+ * https://github.com/hyperledger/aries-rfcs/blob/master/concepts/0017-attachments/README.md
+ */
+export class V2Attachment {
+  public constructor(options: V2AttachmentOptions) {
+    if (options) {
+      this.id = options.id ?? uuid()
+      this.description = options.description
+      this.filename = options.filename
+      this.mediaType = options.mediaType
+      this.data = options.data
+    }
+  }
+
+  @IsOptional()
+  @IsString()
+  public id?: string
+
+  /**
+   * An optional human-readable description of the content.
+   */
+  @IsOptional()
+  @IsString()
+  public description?: string
+
+  /**
+   * A hint about the name that might be used if this attachment is persisted as a file. It is not required, and need not be unique. If this field is present and mime-type is not, the extension on the filename may be used to infer a MIME type.
+   */
+  @IsOptional()
+  @IsString()
+  public filename?: string
+
+  /**
+   * A hint about the attachment format
+   */
+  @IsOptional()
+  @IsString()
+  public format?: string
+
+  /**
+   * Describes the MIME type of the attached content. Optional but recommended.
+   */
+  @Expose({ name: 'media_type' })
+  @IsOptional()
+  @IsMimeType()
+  public mediaType?: string
+
+  @Type(() => AttachmentData)
+  @ValidateNested()
+  @IsInstance(AttachmentData)
+  public data!: AttachmentData
+}

--- a/packages/core/src/modules/out-of-band/messages/OutOfBandInvitationMessage.ts
+++ b/packages/core/src/modules/out-of-band/messages/OutOfBandInvitationMessage.ts
@@ -1,5 +1,5 @@
 import type { DIDCommV2MessageParams } from '../../../agent/didcomm'
-import type { Attachment } from 'didcomm'
+import type { V2Attachment } from '../../../decorators/attachment/V2Attachment'
 
 import { Expose, Type } from 'class-transformer'
 import { IsInstance, IsOptional, IsString, ValidateNested } from 'class-validator'
@@ -67,11 +67,11 @@ export class OutOfBandInvitationMessage extends DIDCommV2Message {
     return JsonTransformer.fromJSON(json, OutOfBandInvitationMessage)
   }
 
-  public static createAndroidNearbyHandshakeJSONAttachment(attachment: AndroidNearbyHandshakeAttachment): Attachment {
+  public static createAndroidNearbyHandshakeJSONAttachment(attachment: AndroidNearbyHandshakeAttachment): V2Attachment {
     return this.createJSONAttachment(ANDROID_NEARBY_HANDSHAKE_ATTACHMENT_ID, JsonTransformer.toJSON(attachment))
   }
 
-  public static createOutOfBandJSONAttachment(attachment: Record<string, unknown>): Attachment {
+  public static createOutOfBandJSONAttachment(attachment: Record<string, unknown>): V2Attachment {
     return this.createJSONAttachment(ATTACHMENT_ID, JsonTransformer.toJSON(attachment))
   }
 

--- a/packages/core/src/modules/routing/protocol/pickup/v3/messages/DeliveryMessage.ts
+++ b/packages/core/src/modules/routing/protocol/pickup/v3/messages/DeliveryMessage.ts
@@ -1,15 +1,15 @@
 import type { DIDCommV2MessageParams } from '../../../../../../agent/didcomm'
-import type { Attachment } from 'didcomm'
 
 import { Type, Expose } from 'class-transformer'
-import { ValidateNested, IsObject, IsOptional, IsString } from 'class-validator'
+import { ValidateNested, IsObject, IsOptional, IsString, IsArray } from 'class-validator'
 
 import { DIDCommV2Message } from '../../../../../../agent/didcomm'
+import { V2Attachment } from '../../../../../../decorators/attachment/V2Attachment'
 import { IsValidMessageType, parseMessageType } from '../../../../../../utils/messageType'
 
 export type DeliveryMessageParams = {
   body: DeliveryBody
-  attachments: Attachment[]
+  attachments: V2Attachment[]
 } & DIDCommV2MessageParams
 
 class DeliveryBody {
@@ -29,7 +29,12 @@ export class DeliveryMessage extends DIDCommV2Message {
   public readonly type = DeliveryMessage.type.messageTypeUri
   public static readonly type = parseMessageType('https://didcomm.org/messagepickup/3.0/delivery')
 
-  public attachments!: Array<Attachment>
+  @Type(() => V2Attachment)
+  @IsArray()
+  @ValidateNested({
+    each: true,
+  })
+  public attachments!: Array<V2Attachment>
 
   public constructor(params?: DeliveryMessageParams) {
     super(params)


### PR DESCRIPTION
# Defined class for DidComm V2 attachment to make class-transformer working

Duplicate of https://github.com/sicpa-dlab/aries-framework-javascript/pull/116 from rebased branch.

**Related ticket on Github:** #https://github.com/sicpa-dlab/cbdc-projects/issues/1727
- @Artemkaaas 
- @dmitry-vychikov 